### PR TITLE
Added new calls to check contracts' security scores

### DIFF
--- a/contracts/CertiKSecurityOracle.sol
+++ b/contracts/CertiKSecurityOracle.sol
@@ -27,11 +27,23 @@ contract CertiKSecurityOracle is Ownable {
   constructor() public {
     initialize();
   }
+  
+  function isContract(address _addr) private view returns (bool) {
+    uint32 size;
+    assembly {
+      size := extcodesize(_addr)
+    }
+    return (size > 0);
+  }
 
   function getSecurityScore(
       address contractAddress,
       bytes4 functionSignature
     ) public view returns (uint8) {
+    if (!isContract(contractAddress)) {
+        return 255;
+    }
+
     Result storage result = _results[contractAddress][functionSignature];
 
     if (result.expiration > block.timestamp) {

--- a/contracts/CertiKSecurityOracle.sol
+++ b/contracts/CertiKSecurityOracle.sol
@@ -28,7 +28,7 @@ contract CertiKSecurityOracle is Ownable {
     initialize();
   }
   
-  function isContract(address _addr) private view returns (bool) {
+  function isContract(address _addr) public view returns (bool) {
     uint32 size;
     assembly {
       size := extcodesize(_addr)


### PR DESCRIPTION
Added a check for the address to be scanned. Return 255 directly if it's not a contract address in newly added calls.