### PR TITLE
add bsc deployment from truffle

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,9 @@ yarn console
 ```
 yarn test
 ```
+
+## Production
+
+```
+TRUFFLE_PRIVATE_KEY="<wallet-key>" TRUFFLE_RPC="<rpc-endpoint>" yarn deploy --network production
+```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Decentralized real-time auditing for your smart contracts.
 
 ## Usage
 
-Follow the following example to integrate. For complicated integrations we can check [DeFiExample](contracts/DeFiexample.sol) for a reference.
+Follow the following example to integrate. For complicated integrations we can check [DeFiExample](contracts/DeFiExample.sol) for a reference.
 
 ```
 interface SecurityOracle {
@@ -61,3 +61,5 @@ yarn test
 ```
 TRUFFLE_PRIVATE_KEY="<wallet-key>" TRUFFLE_RPC="<rpc-endpoint>" yarn deploy --network production
 ```
+
+Note that truffle commands like `truffle migrate`/`truffle deploy`/etc would also require the environment variables.

--- a/migrations/2_create_security_oracle.js
+++ b/migrations/2_create_security_oracle.js
@@ -4,7 +4,7 @@ module.exports = async function(deployer, network, accounts) {
   try {
     await deployer.deploy(CertiKSecurityOracle,
       {
-        from: accounts[1]
+        from: accounts[0]
       }
     );
 

--- a/migrations/3_create_defi_example.js
+++ b/migrations/3_create_defi_example.js
@@ -8,7 +8,7 @@ module.exports = async function (deployer, network, accounts) {
         DeFiExample,
         CertiKSecurityOracle.address,
         {
-          from: accounts[2]
+          from: accounts[0]
         }
       );
 

--- a/migrations/4_create_security_oracle_proxy.js
+++ b/migrations/4_create_security_oracle_proxy.js
@@ -6,7 +6,7 @@ module.exports = async function(deployer, network, accounts) {
     await deployer.deploy(CertiKSecurityOracleProxy,
       CertiKSecurityOracle.address,
       {
-        from: accounts[1]
+        from: accounts[0]
       }
     );
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "truffle build",
     "console": "truffle console",
     "migrate": "truffle migrate",
-    "migrate": "truffle deploy",
+    "deploy": "truffle deploy",
     "test": "truffle test"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "truffle build",
     "console": "truffle console",
-    "migrate": "truffle migrate --network development",
-    "deploy": "truffle deploy --network development",
+    "migrate": "truffle migrate",
+    "migrate": "truffle deploy",
     "test": "truffle test"
   },
   "dependencies": {

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,8 +1,26 @@
+const HDWalletProvider = require("@truffle/hdwallet-provider");
+
 module.exports = {
   networks: {
     development: {
       host: "127.0.0.1",
       port: 7545,
+      network_id: "*"
+    },
+    bsc: {
+      provider: () => {
+        const privateKey = process.env.TRUFFLE_PRIVATE_KEY;
+
+        if (!privateKey) {
+          console.log("missing env var TRUFFLE_PRIVATE_KEY");
+          process.exit(1);
+        }
+
+        return new HDWalletProvider(
+          privateKey,
+          "https://data-seed-prebsc-1-s1.binance.org:8545/"
+        );
+      },
       network_id: "*"
     }
   }

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -7,7 +7,7 @@ module.exports = {
       port: 7545,
       network_id: "*"
     },
-    bsc: {
+    "bsc-test": {
       provider: () => {
         const privateKey = process.env.TRUFFLE_PRIVATE_KEY;
 

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -7,7 +7,7 @@ module.exports = {
       port: 7545,
       network_id: "*"
     },
-    "bsc-test": {
+    production: {
       provider: () => {
         const privateKey = process.env.TRUFFLE_PRIVATE_KEY;
 
@@ -16,10 +16,14 @@ module.exports = {
           process.exit(1);
         }
 
-        return new HDWalletProvider(
-          privateKey,
-          "https://data-seed-prebsc-1-s1.binance.org:8545/"
-        );
+        const rpc = process.env.TRUFFLE_RPC;
+
+        if (!rpc) {
+          console.log("missing env var TRUFFLE_RPC");
+          process.exit(1);
+        }
+
+        return new HDWalletProvider(privateKey, rpc);
       },
       network_id: "*"
     }


### PR DESCRIPTION
Add support for Binance Smart Chain and other public chain deployments. After the change, we can deploy with `TRUFFLE_PRIVATE_KEY="<wallet-key>" TRUFFLE_RPC="<rpc-endpoint>" yarn deploy --network production`.

for bsc, we can deploy bsc testnet with:

```
$ TRUFFLE_PRIVATE_KEY=xxx TRUFFLE_RPC="https://data-seed-prebsc-1-s1.binance.org:8545" yarn console --network production
yarn run v1.22.4
$ truffle console --network production
truffle(production)> c = await CertiKSecurityOracle.deployed()
undefined
truffle(production)> score = await c.getSecurityScore(accounts[0])
undefined
truffle(production)> score.toString()
'128'
```