### PR TITLE
Lock compiler version to 0.5.17

### DIFF
--- a/contracts/CertiKSecurityOracle.sol
+++ b/contracts/CertiKSecurityOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.5.0;
+pragma solidity 0.5.17;
 
 import "./openzeppelin/Ownable.sol";
 

--- a/contracts/CertiKSecurityOracleProxy.sol
+++ b/contracts/CertiKSecurityOracleProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.5.0 <0.6.0;
+pragma solidity 0.5.17;
 
 import "./openzeppelin/Ownable.sol";
 import "./openzeppelin/Proxy.sol";

--- a/contracts/DeFiExample.sol
+++ b/contracts/DeFiExample.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.5.0 <0.7.0;
+pragma solidity 0.5.17;
 
 interface SecurityOracle {
   function getSecurityScore(address contractAddress) external view returns (uint8);

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.4.25 <0.7.0;
+pragma solidity 0.5.17;
 
 contract Migrations {
   address public owner;

--- a/contracts/openzeppelin/Context.sol
+++ b/contracts/openzeppelin/Context.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.5.0 <0.7.0;
+pragma solidity 0.5.17;
 
 /*
  * @dev Provides information about the current execution context, including the

--- a/contracts/openzeppelin/Ownable.sol
+++ b/contracts/openzeppelin/Ownable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.5.0 <0.7.0;
+pragma solidity 0.5.17;
 
 import "./Context.sol";
 /**

--- a/contracts/openzeppelin/Proxy.sol
+++ b/contracts/openzeppelin/Proxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.5.0 <0.6.0;
+pragma solidity 0.5.17;
 
 /**
  * @title Proxy

--- a/test/TestProxy.sol
+++ b/test/TestProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.5.0 <0.6.0;
+pragma solidity 0.5.17;
 
 import "truffle/Assert.sol";
 import "truffle/DeployedAddresses.sol";

--- a/test/TestSecurityOracle.sol
+++ b/test/TestSecurityOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.5 <0.6.0;
+pragma solidity 0.5.17;
 
 import "truffle/Assert.sol";
 import "../contracts/CertiKSecurityOracle.sol";

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -27,5 +27,10 @@ module.exports = {
       },
       network_id: "*"
     }
+  },
+  compilers: {
+    solc: {
+       version: "0.5.17"
+    }
   }
 };


### PR DESCRIPTION
Lock the compiler version to 0.5.17.
Tested on local environment through `yarn test` command.