### PR TITLE
improve handling for special zero byte4 value, remove ambiguity

### DIFF
--- a/contracts/DeFiExample.sol
+++ b/contracts/DeFiExample.sol
@@ -2,18 +2,31 @@
 pragma solidity 0.5.17;
 
 interface SecurityOracle {
-  function getSecurityScore(address contractAddress) external view returns (uint8);
+  function getSecurityScore(address contractAddress)
+    external
+    view
+    returns (uint8);
 
-  function getSecurityScore(address contractAddress, string calldata functionSignature) external view returns (uint8);
+  function getSecurityScore(
+    address contractAddress,
+    string calldata functionSignature
+  ) external view returns (uint8);
 
-  function getSecurityScore(address contractAddress, bytes4 functionSignature) external view returns (uint8);
+  function getSecurityScoreBytes4(
+    address contractAddress,
+    bytes4 functionSignature
+  ) external view returns (uint8);
 
-  function getSecurityScores(address[] calldata addresses, bytes4[] calldata functionSignatures) external view returns (uint8[] memory);
+  function getSecurityScores(
+    address[] calldata addresses,
+    bytes4[] calldata functionSignatures
+  ) external view returns (uint8[] memory);
 }
 
 contract DeFiExample {
   event Score(uint8 score);
-  event Success(address addr, bytes4 sig);
+  event SuccessBytes4(address addr, bytes4 sig);
+  event SuccessString(address addr, string sig);
 
   address private _securityOracleAddress;
 
@@ -21,7 +34,7 @@ contract DeFiExample {
     _securityOracleAddress = securityOracleAddress;
   }
 
-  function callGetSecurityScore(address addr, bytes4 sig) public {
+  function callGetSecurityScore(address addr, string memory sig) public {
     uint8 score = SecurityOracle(_securityOracleAddress).getSecurityScore(
       addr,
       sig
@@ -31,7 +44,20 @@ contract DeFiExample {
 
     require(score > 100, "revert due to high security risk");
 
-    emit Success(addr, sig);
+    emit SuccessString(addr, sig);
+  }
+
+  function callGetSecurityScoreBytes4(address addr, bytes4 sig) public {
+    uint8 score = SecurityOracle(_securityOracleAddress).getSecurityScoreBytes4(
+      addr,
+      sig
+    );
+
+    emit Score(score);
+
+    require(score > 100, "revert due to high security risk");
+
+    emit SuccessBytes4(addr, sig);
   }
 
   function callGetSecurityScores() public view {

--- a/test/TestSecurityOracle.js
+++ b/test/TestSecurityOracle.js
@@ -1,0 +1,59 @@
+const SecurityOracle = artifacts.require("CertiKSecurityOracle");
+
+async function tryCatch(promise, message) {
+  const PREFIX = "VM Exception while processing transaction: ";
+
+  try {
+    await promise;
+    throw null;
+  } catch (error) {
+    assert(error, "Expected an error but did not get one");
+    assert(
+      error.message.indexOf(PREFIX + message) !== -1,
+      "Expected an error containing '" +
+        PREFIX +
+        message +
+        "' but got '" +
+        error.message +
+        "' instead"
+    );
+  }
+}
+
+contract("SecurityOracle", () => {
+  let so;
+
+  before(async function () {
+    so = await SecurityOracle.new();
+  });
+
+  it("should proceed for contract address only call", async function () {
+    await so.getSecurityScore("0xc06Ca4a7DaEB0D1601Bb47297d9Fd170f231D872");
+  });
+
+  it("should revert if contract address is 0", async function () {
+    await tryCatch(
+      so.getSecurityScore("0x0000000000000000000000000000000000000000"),
+      "revert"
+    );
+  });
+
+  it("should proceed for contract address and non 0 function signature call", async function () {
+    await so.getSecurityScoreBytes4(
+      "0xc06Ca4a7DaEB0D1601Bb47297d9Fd170f231D872",
+      [0, 0, 0, 1]
+    );
+  });
+
+  it("should revert if function signature is 0", async function () {
+    await tryCatch(
+      so.getSecurityScoreBytes4("0xc06Ca4a7DaEB0D1601Bb47297d9Fd170f231D872", [
+        0,
+        0,
+        0,
+        0
+      ]),
+      "revert"
+    );
+  });
+});

--- a/test/TestSecurityOracle.sol
+++ b/test/TestSecurityOracle.sol
@@ -28,7 +28,7 @@ contract TestSecurityOracle {
 
   function testGetSecurityScoreResultMissing() public {
     uint256 score = uint256(
-      so.getSecurityScore(
+      so.getSecurityScoreBytes4(
         msg.sender,
         bytes4(keccak256(abi.encodePacked("getPrice(string)")))
       )
@@ -74,7 +74,7 @@ contract TestSecurityOracle {
     );
 
     uint256 score = uint256(
-      so.getSecurityScore(
+      so.getSecurityScoreBytes4(
         msg.sender,
         bytes4(keccak256(abi.encodePacked("getPrice(string)")))
       )
@@ -98,7 +98,7 @@ contract TestSecurityOracle {
     );
 
     uint256 score = uint256(
-      so.getSecurityScore(
+      so.getSecurityScoreBytes4(
         msg.sender,
         bytes4(keccak256(abi.encodePacked("getPrice(string)")))
       )
@@ -137,7 +137,7 @@ contract TestSecurityOracle {
     );
 
     uint256 func1Score = uint256(
-      so.getSecurityScore(
+      so.getSecurityScoreBytes4(
         msg.sender,
         bytes4(keccak256(abi.encodePacked("func1()")))
       )
@@ -150,7 +150,7 @@ contract TestSecurityOracle {
     );
 
     uint256 func2Score = uint256(
-      so.getSecurityScore(
+      so.getSecurityScoreBytes4(
         msg.sender,
         bytes4(keccak256(abi.encodePacked("func2()")))
       )


### PR DESCRIPTION
Changes:

- bytes4(0) is not allowed for direct call, it became a reserved special value, in this way we removed ambiguity (with a little bit cost for usability, but the conflict chance is very low 1/65536)
- add tests for revert cases

Tests:

```
  TestProxy
    ✓ testProxy (90ms)
    ✓ testUpgradeOracleAddress (110ms)

  TestSecurityOracle
    ✓ testDefaultScore (76ms)
    ✓ testUpdateDefaultScore (127ms)
    ✓ testGetSecurityScoreResultMissing (116ms)
    ✓ testGetSecurityScoreStringParameter (89ms)
    ✓ testGetSecurityScoreContractAddressOnly (94ms)
    ✓ testPushResultResultAvailable (86ms)
    ✓ testPushResultResultExpired (131ms)
    ✓ testBatchPushResult (199ms)
    ✓ testGetSecurityScores (105ms)

  Contract: SecurityOracle
    ✓ should proceed for contract address only call
    ✓ should revert if contract address is 0
    ✓ should proceed for contract address and non 0 function signature call
    ✓ should revert if function signature is 0


  15 passing (14s)

✨  Done in 20.79s.
```